### PR TITLE
Remove tracking script for https://astro-digital-garden.stereobooster…

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,18 +64,6 @@ export default defineConfig({
         // Sidebar: "./src/components/Sidebar.astro",
       },
       lastUpdated: true,
-      head: import.meta.env.PROD
-        ? [
-            {
-              tag: "script",
-              attrs: {
-                src: "https://eu.umami.is/script.js",
-                "data-website-id": "2d34b0d4-893c-4348-a3e4-1f489300117c",
-                defer: true,
-              },
-            },
-          ]
-        : undefined,
     }),
   ],
   markdown: {


### PR DESCRIPTION
….com/

this is tracking script (like Google analytics). Please remove it, otherwise visits to your website shows up in my statistics.

Thank you